### PR TITLE
Refactor WebSocket neighbor storage to map

### DIFF
--- a/src/core/App.ts
+++ b/src/core/App.ts
@@ -24,17 +24,15 @@ export default class App {
   timerInterval: number | null = null;
   level: number = 0;
   targets: Cube[] = [];
-  neighbors: PlayerCore[] = [];
   gameRunning: boolean = false;
   wsManager: WSManager;
   constructor() {
     this.timerElement = document.getElementById("timer")!;
     this.gameRunning = false;
     this.camera = new Camera();
-    this.wsManager = new WSManager(this.neighbors);
+    this.wsManager = new WSManager();
     this.scene = new MainScene(
       this.targets,
-      this.neighbors,
       this.wsManager.getMe()!,
       this.wsManager
     );

--- a/src/scenes/MainScene.ts
+++ b/src/scenes/MainScene.ts
@@ -7,19 +7,16 @@ import type { PlayerCore } from "../utils/ws/WSManager";
 import WSManager from "../utils/ws/WSManager";
 export default class MainScene extends THREE.Scene {
   public targets: Cube[] = [];
-  public neighbors: PlayerCore[] = [];
   public me: PlayerCore;
   public wsManager: WSManager;
   constructor(
     targets: Cube[],
-    neighbors: PlayerCore[],
     me: PlayerCore,
     wsManager: WSManager
   ) {
     super();
     const white = new THREE.Color(0xffffff);
     this.background = white;
-    this.neighbors = neighbors;
     this.targets = targets;
     this.me = me;
     this.wsManager = wsManager;
@@ -29,7 +26,7 @@ export default class MainScene extends THREE.Scene {
 
   public initPlayerRoom(playerCore: PlayerCore) {
     this.me = playerCore;
-    console.log(this.me, "me", this.neighbors, "neighbors");
+    console.log(this.me, "me", this.wsManager.getNeighbors(), "neighbors");
     this.generateRoom(playerCore.room_coord_x, playerCore.room_coord_z);
   }
   private generateRoom(x: number, z: number) {
@@ -55,9 +52,11 @@ export default class MainScene extends THREE.Scene {
     }
     this.generateCubes(3, this.me.room_coord_x, this.me.room_coord_z);
 
-    this.neighbors.forEach((neighbor) => {
-      this.generateRoom(neighbor.room_coord_x, neighbor.room_coord_z);
-    });
+    this.wsManager
+      .getNeighbors()
+      .forEach((neighbor) => {
+        this.generateRoom(neighbor.room_coord_x, neighbor.room_coord_z);
+      });
   }
 
   public generateCubes(amount: number, roomCoordX: number, roomCoordZ: number) {
@@ -82,8 +81,10 @@ export default class MainScene extends THREE.Scene {
   }
 
   public update() {
-    this.neighbors.forEach((neighbor) => {
-      this.generateRoom(neighbor.room_coord_x, neighbor.room_coord_z);
-    });
+    this.wsManager
+      .getNeighbors()
+      .forEach((neighbor) => {
+        this.generateRoom(neighbor.room_coord_x, neighbor.room_coord_z);
+      });
   }
 }


### PR DESCRIPTION
## Summary
- replace WS neighbor array with Map for fast lookup and updates
- delete neighbors on disconnect and expose neighbors as Array from Map
- update main scene and app to consume map-based neighbor list

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: src/objects/RandomCubeGenerator.ts(6,11): error TS6133: 'scene' is declared but its value is never read.)*

------
https://chatgpt.com/codex/tasks/task_e_689f76e4485c83308b464f3c9d0f8c63